### PR TITLE
Update posts.mdx

### DIFF
--- a/src/content/docs/getting-started/posts.mdx
+++ b/src/content/docs/getting-started/posts.mdx
@@ -432,7 +432,7 @@ ways to get an individual Post, but using the `postBy` query.
 
 <GraphiQL
   query="
-  query GET_POST( $postId: Int ) {
+  query GET_POST( $postId: ID ) {
     postBy( postId: $postId ) {
       id
       postId


### PR DESCRIPTION
Fix example. `$postId` is an `ID`

Current example errors:
```
{
  "errors": [
    {
      "message": "Variable \"$postId\" of type \"Int\" used in position expecting type \"ID\".",
      "category": "graphql",
      "locations": [
        {
          "line": 1,
          "column": 16
        },
        {
          "line": 2,
          "column": 18
        }
      ]
    }
  ]
}
```