### PR TITLE
Fix a minor error in Hierarchical Taxonomies section

### DIFF
--- a/src/content/getting-started/categories-and-tags.mdx
+++ b/src/content/getting-started/categories-and-tags.mdx
@@ -137,7 +137,7 @@ The children of those categories can be queried like so:
                 id
                 name
                 children {
-                  node {
+                  nodes {
                     id
                     name
                   }


### PR DESCRIPTION
Since the children expects `nodes` instead of `node`, it needs to be updated.