### PR TITLE
Fix example for getting a page by it's database ID

### DIFF
--- a/src/content/getting-started/pages.mdx
+++ b/src/content/getting-started/pages.mdx
@@ -432,7 +432,7 @@ ways to get an individual Page, but using the `pageBy` query.
 
 <GraphiQL
   query="
-  query GET_PAGE( $pageId: ID ) {
+  query GET_PAGE( $pageId: Int ) {
     pageBy( pageId: $pageId ) {
       id
       pageId


### PR DESCRIPTION
`$pageId` is an `Int` type not an `ID` type