### PR TITLE
fix a couple of links to relay-spec

### DIFF
--- a/src/content/getting-started/pages.mdx
+++ b/src/content/getting-started/pages.mdx
@@ -48,7 +48,7 @@ One of the first things you may ask when you see this is: <strong><em>"What in t
 We've written up a guide on what they are and why WPGraphQL makes use of this shape of data
 throughout.
 
-<a href="/docs/guides/relay-spec"><Button type="primary">Read the Guide</Button></a>
+<a href="/guides/relay-spec"><Button type="primary">Read the Guide</Button></a>
 </Note>
 
 ### Hierarchical Post Types

--- a/src/content/getting-started/users.mdx
+++ b/src/content/getting-started/users.mdx
@@ -47,7 +47,7 @@ One of the first things you may ask when you see this is: <strong><em>"What in t
 We've written up a guide on what they are and why WPGraphQL makes use of this shape of data
 throughout.
 
-<a href="/docs/guides/relay-spec"><Button type="primary">Read the Guide</Button></a>
+<a href="/guides/relay-spec"><Button type="primary">Read the Guide</Button></a>
 </Note>
 
 ### Connected Data


### PR DESCRIPTION
I saw you just added docs about the relay spec 3 hours ago—thank you!!

This fixes a couple of URLs pointing to their old location.