### PR TITLE
Link to "Intro to GraphQL" is incorrect

### DIFF
--- a/src/content/getting-started/posts.mdx
+++ b/src/content/getting-started/posts.mdx
@@ -12,7 +12,7 @@ with Posts using WPGraphQL.
 
 <Note type="warning">
 If any of the terminology or semantics of the GraphQL queries/mutations on this page are confusing,
-check out the <a href="/docs/getting-started/intro-to-graphql">Intro to GraphQL Guide</a> to get
+check out the <a href="/getting-started/intro-to-graphql">Intro to GraphQL Guide</a> to get
 more familiar with the basics.
 </Note>
 


### PR DESCRIPTION
Link doesn't work when viewing page from https://docs.wpgraphql.com/getting-started/posts

Don't know if this is old URL structure or not.