### PR TITLE
Remove broken link

### DIFF
--- a/src/content/getting-started/install-and-activate.mdx
+++ b/src/content/getting-started/install-and-activate.mdx
@@ -58,9 +58,7 @@ the plugin screen, or via WP CLI `wp plugin activate wp-graphql`
 The most common use of WPGraphQL is as an API endpoint that can be accessed via HTTP requests
 (although it can be used without remote HTTP requests as well)
 
-In order for the `/graphql` endpoint to work, **you must have
-[pretty permalinks](https://wpgraphql.com/docs/getting-started/install-and-activate#flush-permalinks)
-enabled** and any permalink structure other than the default WordPress permalink structure.
+In order for the `/graphql` endpoint to work, **you must have pretty permalinks enabled** and any permalink structure other than the default WordPress permalink structure.
 
 Once the plugin is active, your site should have a `example.com/graphql` endpoint and you the
 expected response is a JSON payload like so:


### PR DESCRIPTION
This link is broken https://docs.wpgraphql.com/getting-started/install-and-activate#flush-permalinks and I can't find a relevant replacement in the docs.