### PR TITLE
Fix broken docs url as per #78

### DIFF
--- a/src/content/getting-started/interacting-with-wpgraphql.mdx
+++ b/src/content/getting-started/interacting-with-wpgraphql.mdx
@@ -10,7 +10,7 @@ On this page, you will find details on the various ways you can interact with yo
 
 <Note title="Understanding GraphQL Queries" type="warning">
 On this page you will see examples of GraphQL queries. Don't worry if it looks foreign right now. We'll go over
-what it all means in the <a href="/docs/getting-started/intro-to-graphql">Intro to GraphQL Guide</a>
+what it all means in the <a href="/getting-started/intro-to-graphql">Intro to GraphQL Guide</a>
 </Note>
 
 ## GraphQL IDEs and Tools


### PR DESCRIPTION
Link doesn't work when viewing page from https://docs.wpgraphql.com/getting-started/posts